### PR TITLE
fix: Rubocopエラーの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails'
 
-    gem 'guard-rspec'
+  gem 'guard-rspec'
 end
 
 group :development do
@@ -85,5 +85,4 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 5.0'
   gem 'timecop'
-  gem 'selenium-webdriver'
 end

--- a/spec/models/study_record_spec.rb
+++ b/spec/models/study_record_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe StudyRecord, type: :model do
 
     #-- .need_review スコープのテスト ---
     describe '.need_review' do
-  let!(:need_review_record) { create(:study_record, :need_review) }
-  let!(:scheduled_record)   { create(:study_record, :scheduled) }
-  let!(:completed_record)   { create(:study_record, :completed) }
+      let!(:need_review_record) { create(:study_record, :need_review) }
+      let!(:scheduled_record)   { create(:study_record, :scheduled) }
+      let!(:completed_record)   { create(:study_record, :completed) }
 
       # -- 過去のnext_review_atを持つレコードが含まれることの確認 ---
       it 'includes records with past next_review_at' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 # Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin
@@ -78,7 +78,7 @@ RSpec.configure do |config|
 
   config.include Warden::Test::Helpers
   config.before(:suite) { Warden.test_mode! }
-  config.after(:each) { Warden.test_reset! }
+  config.after { Warden.test_reset! }
 
   config.before(:each, type: :system) do
     driven_by :remote_chrome

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,7 +9,7 @@ Capybara.register_driver :remote_chrome do |app|
   options.add_argument('disable-gpu')
   options.add_argument('disable-dev-shm-usage')
   options.add_argument('window-size=1680,1050')
-  
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :remote,

--- a/spec/system/study_records_spec.rb
+++ b/spec/system/study_records_spec.rb
@@ -3,27 +3,25 @@ require 'rails_helper'
 
 RSpec.describe 'StudyRecords', type: :system do
   let(:user) { create(:user) }
+  let(:valid_attributes) do
+    {
+      title: 'テストタイトル',
+      content: 'テスト内容',
+      category: 'ruby',
+      studied_at: Time.zone.today
+    }
+  end
+  let(:updated_attributes) do
+    {
+      title: '更新されたタイトル',
+      content: '更新内容',
+      category: 'rails',
+      studied_at: Time.zone.today
+    }
+  end
 
   before do
     sign_in user
-  end
-
-  let(:valid_attributes) do
-    {
-      title: "テストタイトル",
-      content: "テスト内容",
-      category: "ruby",
-      studied_at: Date.today
-    }
-  end
-
-  let(:updated_attributes) do
-    {
-      title: "更新されたタイトル",
-      content: "更新内容",
-      category: "rails",
-      studied_at: Date.today
-    }
   end
 
   # ==============================
@@ -63,7 +61,7 @@ RSpec.describe 'StudyRecords', type: :system do
   # ==============================
   describe '詳細画面' do
     let!(:study_record) do
-      create(:study_record, user: user, title: 'Railsの基礎', content: 'MVCについて学習した', category: 'rails', studied_at: Date.new(2025,1,1))
+      create(:study_record, user: user, title: 'Railsの基礎', content: 'MVCについて学習した', category: 'rails', studied_at: Date.new(2025, 1, 1))
     end
 
     it '内容が表示される' do
@@ -122,7 +120,7 @@ RSpec.describe 'StudyRecords', type: :system do
   # 復習ボタン表示
   # ==============================
   describe '復習機能' do
-    context '復習可能な学習記録' do
+    context 'when 復習可能な学習記録がある場合' do
       let!(:study_record) { create(:study_record, user: user, next_review_at: 1.day.ago, review_count: 0) }
 
       it '今すぐ復習ボタンが表示される' do
@@ -131,7 +129,7 @@ RSpec.describe 'StudyRecords', type: :system do
       end
     end
 
-    context '復習未到来の学習記録' do
+    context 'when 復習未到来の学習記録がある場合' do
       let!(:study_record) { create(:study_record, user: user, next_review_at: 3.days.from_now, review_count: 0) }
 
       it '下部の復習ボタンのみ表示される' do

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe "UserSessions", type: :system do
+RSpec.describe 'UserSessions', type: :system do
   let(:user) { create(:user) }
 
   describe 'ログイン' do
-    context '正しい認証情報でログインできる' do
+    context 'with 正しい認証情報' do
       it 'ログインできる' do
         visit new_user_session_path
 
         fill_in 'メールアドレス', with: user.email
         fill_in 'パスワード', with: user.password
-        
+
         click_button 'ログイン'
 
         expect(page).to have_content('ログインしました。')
@@ -19,13 +19,13 @@ RSpec.describe "UserSessions", type: :system do
       end
     end
 
-    context '誤った認証情報ではログインできない' do
+    context 'with 誤った認証情報' do
       it 'ログインフォームが再表示される' do
         visit new_user_session_path
 
         fill_in 'メールアドレス', with: user.email
         fill_in 'パスワード', with: 'wrong_password'
-        
+
         click_button 'ログイン'
 
         # ログインフォームが再表示されることを確認
@@ -43,9 +43,9 @@ RSpec.describe "UserSessions", type: :system do
 
     it 'ログアウトできる' do
       expect(page).to have_content("ようこそ、 #{user.name}さん")
-      
+
       click_link 'ログアウト'
-      
+
       expect(page).to have_content('ログアウトしました。')
       expect(current_path).to eq(root_path)
       expect(page).to have_link('ログイン', href: new_user_session_path)


### PR DESCRIPTION
## 概要
- Rubocopの修正

### 実装内容
- Rubocopの実装のミスを修正
- gem 'selenium-webdriver'　が重複していたので削除した

### 実装結果
[![Image from Gyazo](https://i.gyazo.com/f47755da6790c4d792a3cd7ad2f46975.png)](https://gyazo.com/f47755da6790c4d792a3cd7ad2f46975)