### PR TITLE
Fix: categories_i18n

### DIFF
--- a/app/models/study_record.rb
+++ b/app/models/study_record.rb
@@ -63,6 +63,20 @@ class StudyRecord < ApplicationRecord
     :scheduled
   end
 
+  # ===== i18n関連メソッド =====
+
+  # === セレクトボックス用: カテゴリの選択肢を日本語で返す ===
+  def self.category_options
+    categories.keys.map do |k|
+      [I18n.t("activerecord.enums.study_record.category.#{k}"), k.to_s]
+    end
+  end
+
+  # === 表示用: 個別レコードのカテゴリを日本語に変換 ===
+  def category_i18n
+    I18n.t("activerecord.enums.study_record.category.#{category}")
+  end
+
   private
 
   # === 初期化 ===

--- a/app/views/study_records/_form.html.erb
+++ b/app/views/study_records/_form.html.erb
@@ -30,8 +30,8 @@
         <%# カテゴリ %>
         <div>
           <%= f.label :category, 'カテゴリ', class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.select :category, 
-            StudyRecord.categories.keys.map { |k| [k.titleize, k.to_s] }, 
+          <%= f.select :category,
+            StudyRecord.category_options,
             { include_blank: '選択してください' },
             class: "w-full px-4 py-2 border rounded-lg transition-colors focus:ring-2 focus:ring-blue-500 focus:border-blue-500 #{'border-red-500' if study_record.errors[:category].any?}" %>
           <% if study_record.errors[:category].any? %>

--- a/app/views/study_records/index.html.erb
+++ b/app/views/study_records/index.html.erb
@@ -47,7 +47,7 @@
             <p class="flex items-center gap-2">
               <span class="font-medium text-slate-700">📚 カテゴリ:</span>
               <span class="text-slate-800">
-                <%= record.category_rails? ? 'Rails' : record.category.humanize %>
+                <%= record.category_i18n %>
               </span>
             </p>
             

--- a/app/views/study_records/show.html.erb
+++ b/app/views/study_records/show.html.erb
@@ -11,7 +11,7 @@
     <p class="flex items-center">
       <span class="font-medium text-slate-800 mr-2">📚 カテゴリ:</span>
       <span class="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full text-xs font-medium">
-        <%= @study_record.category_rails? ? 'Rails' : @study_record.category.humanize %>
+        <%= record.category_i18n %>
       </span>
     </p>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,6 +17,15 @@ ja:
         studied_at: "学習日"
         created_at: "作成日時"
         updated_at: "更新日時"
+    enums:
+      study_record:
+        category:
+          rails: "Rails"
+          ruby: "Ruby"
+          javascript: "JavaScript"
+          css: "CSS"
+          html: "HTML"
+          other: "その他"
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"


### PR DESCRIPTION
## 概要
- カテゴリをi18nで表記するように変更した

### 実装内容
- config/locales/ja.yml　に**enum**を追加
-  app/models/study_record.rb に表示するセレクトカテゴリを日本語に返す動作を追加
- app/views/study_records/_form.html.erb にカテゴリ欄にi18nのメソッドを追加
- app/views/study_records/index.html.erb, app/views/study_records/show.html.erb にてカテゴリのi18nを追加

### 実装結果
[![Image from Gyazo](https://i.gyazo.com/67ff427cbc9d6b178e1bff8528825792.png)](https://gyazo.com/67ff427cbc9d6b178e1bff8528825792)