### PR TITLE
Add: ヘッダーにログイン後の学習一覧ページに遷移できる導線を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,8 @@
         <nav class="flex items-center gap-4">
           <% if user_signed_in? %>
             <span class="text-slate-700">ようこそ、 <%= current_user.name %>さん</span>
+            <%= link_to '学習記録', study_records_path,
+                    class: "px-4 py-2 rounded bg-blue-500 text-white hover:bg-blue-600 transition" %>
             <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete },
                         class: "px-4 py-2 rounded bg-red-500 text-white hover:bg-red-600 transition" %>
           <% else %>


### PR DESCRIPTION
## 概要
- ログイン後のトップページから学習記録一覧ページに遷移するユーザビリティを加えた

### 実装内容
- app/views/layouts/application.html.erb, ログイン後ヘッダーに学習記録一覧ページに遷移できるようにボタンを追加した

### 実装結果
[![Image from Gyazo](https://i.gyazo.com/b9ac61d6dfd837a366dbc9b57b7df04d.png)](https://gyazo.com/b9ac61d6dfd837a366dbc9b57b7df04d)